### PR TITLE
specify dependencies commit hashes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,11 +15,11 @@ board = esp32-2432S028Rv3
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-    https://github.com/lucadentella/TOTP-Arduino.git
-    https://github.com/rzeldent/esp32-smartdisplay.git
-    https://github.com/NetRat/Base32.git
-    https://github.com/PaulStoffregen/Time.git
-    https://github.com/fbiego/ESP32Time
+    https://github.com/lucadentella/TOTP-Arduino.git#aad39274fd4508623bf423730e4cc7f529c80a9
+    https://github.com/rzeldent/esp32-smartdisplay.git#38956edb0aac544fb725ded3eee3196fbad8223a
+    https://github.com/NetRat/Base32.git#1c65e655360882074f33837ae53f777aee88418e
+    https://github.com/PaulStoffregen/Time.git#a18e50dcea4ee17285d732d39e7bc559482d1d3d
+    https://github.com/fbiego/ESP32Time.git#cefc6857b583ae5478000da897c838a6bf6d3275
 build_flags =
     -Ofast
     -Wall


### PR DESCRIPTION
chore: hardcode dependencies commit hashes because platform.io does not have a lock file. These dependencies are guaranteed to result in a working build