### PR TITLE
fix: the following fixes were implemented

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,16 @@
+// NOTE: used when reading data from the SD card
+#define TF_CS 5
+
+// NOTE: NTP server variables
+#define NTP_SERVER_URL "pool.ntp.org"
+#define GMT_OFFSET_SEC 0
+#define DAYLIGHT_OFFSET_SEC 3600
+
+// NOTE: all totps must have a period of 30 seconds, for now
+#define TOTP_PERIOD 30
+// NOTE: due to mem limits there has to exist a max number of services we can generate TOTPs for
+#define MAX_NUMBER_OF_SERVICES 10
+// NOTE: 60 digits + 1 for the null-terminating character
+#define MAX_SERVICE_NAME_LENGTH 61
+// NOTE: 6 digits + 1 for the null-terminating character
+#define MAX_TOTP_LENGTH 7

--- a/src/mfa.cpp
+++ b/src/mfa.cpp
@@ -5,28 +5,30 @@
 
 // Local Includes
 #include "totp-map.h"
+#include "constants.h"
 
 extern ESP32Time rtc;
-extern char keys[MAX_SIZE][21];
-extern DecodedBase32Secret decodedBase32Secrets[MAX_SIZE];
+extern char keys[MAX_NUMBER_OF_SERVICES][MAX_SERVICE_NAME_LENGTH];
+extern DecodedBase32Secret decodedBase32Secrets[MAX_NUMBER_OF_SERVICES];
 
 long get_steps() {
   rtc.getTime();
   long t = rtc.getEpoch();
-  long steps = t / 30;
+  long steps = t / TOTP_PERIOD;
+  Serial.println(rtc.getEpoch());
   return steps;
 }
 
-char* generate_totp(const DecodedBase32Secret decodedBase32Secret) {
+char* generate_totp(const DecodedBase32Secret decodedBase32Secret, long steps) {
   TOTP totp = TOTP((uint8_t*)decodedBase32Secret.value, decodedBase32Secret.length);
-  long steps = get_steps();
   char* newTotp = totp.getCodeFromSteps(steps); 
   return newTotp;
 }
 
 void generate_totps(){
+  long steps = get_steps();
   for(int i = 0; i < size; i++) {
-    char *totp = generate_totp(decodedBase32Secrets[i]);
+    char *totp = generate_totp(decodedBase32Secrets[i], steps);
     upsert_totp(keys[i], totp);
   }
 }

--- a/src/totp-map.c
+++ b/src/totp-map.c
@@ -1,8 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-
-// NOTE: Due to mem limits there has to exist a max number of services we can generate TOTPs for
-#define MAX_SIZE 10 
+#include "constants.h"
 
 // NOTE: define byte if it's not yet defined
 typedef unsigned char byte; 
@@ -14,9 +12,9 @@ typedef struct {
 
 // NOTE: initialize all stores with null
 int size = 0;
-char keys[MAX_SIZE][21] = {{'\0'}};
-DecodedBase32Secret decodedBase32Secrets[MAX_SIZE] = {0};
-char totps[MAX_SIZE][7] = {{'\0'}};
+char keys[MAX_NUMBER_OF_SERVICES][MAX_SERVICE_NAME_LENGTH] = {{'\0'}};
+DecodedBase32Secret decodedBase32Secrets[MAX_NUMBER_OF_SERVICES] = {0};
+char totps[MAX_NUMBER_OF_SERVICES][MAX_TOTP_LENGTH] = {{'\0'}};
 
 int get_index(char key[]){
     for (int i = 0; i < size; i++) {

--- a/src/totp-map.h
+++ b/src/totp-map.h
@@ -1,19 +1,19 @@
 #pragma once
 #include <string.h>
 #include <stdio.h>
+#include "constants.h"
 
-#define MAX_SIZE 10 // max number of services supported
-
-typedef unsigned char byte; // define byte if it's not yet defined
+// NOTE: define byte if it's not yet defined
+typedef unsigned char byte; 
 
 typedef struct {
     int length;
     byte* value;
 } DecodedBase32Secret;
 
-extern char keys[MAX_SIZE][21];
-extern DecodedBase32Secret decodedBase32Secrets[MAX_SIZE]; // Array to store the secrets
-extern char totps[MAX_SIZE][7]; // Array to store the totps
+extern char keys[MAX_NUMBER_OF_SERVICES][MAX_SERVICE_NAME_LENGTH];
+extern DecodedBase32Secret decodedBase32Secrets[MAX_NUMBER_OF_SERVICES];
+extern char totps[MAX_NUMBER_OF_SERVICES][MAX_TOTP_LENGTH];
 
 // Current number of elements in the map
 extern int size;

--- a/src/ui/screens/ui_totp_screen.c
+++ b/src/ui/screens/ui_totp_screen.c
@@ -5,12 +5,12 @@
 
 #include "../ui.h"
 #include "totp-map.h"
+#include "constants.h"
 
-extern char keys[MAX_SIZE][21];
-extern char totps[MAX_SIZE][7];
+extern char keys[MAX_NUMBER_OF_SERVICES][MAX_SERVICE_NAME_LENGTH];
+extern char totps[MAX_NUMBER_OF_SERVICES][MAX_TOTP_LENGTH];
 
 #define LV_LABEL_SCROLL_SPEED (15)
-
 
 lv_obj_t* create_totp_component(
 	lv_obj_t* parent,
@@ -70,12 +70,13 @@ void ui_totp_screen_screen_init(void){
 	lv_obj_set_style_bg_opa(ui_totp_screen, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
     lv_obj_set_style_pad_all(ui_totp_screen, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-	// Set up flex container properties for the screen
+	// NOTE: set up flex container properties for the screen
     lv_obj_set_flex_flow(ui_totp_screen, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(ui_totp_screen, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     lv_obj_set_layout(ui_totp_screen, LV_LAYOUT_FLEX);
 
-	for(int i = 0; i < MAX_SIZE; i++){
+    // NOTE: create 1 component for each TOTP
+	for(int i = 0; i < MAX_NUMBER_OF_SERVICES; i++){
         if (totps[i][0] != '\0') {
             create_totp_component(ui_totp_screen, keys[i], totps[i], 30, 30);
         }

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -7,6 +7,7 @@
 #include "totp-map.h"
 #include "esp_log.h"
 #include <time.h>
+#include "constants.h"
 
 extern int setup_complete;
 extern uint32_t LV_EVENT_SETUP_COMPLETE;
@@ -16,7 +17,7 @@ int calculate_new_bar_value(){
     time_t now;
     time(&now); 
     timeinfo = localtime(&now); 
-    int val = 30 - timeinfo->tm_sec % 30; 
+    int val = TOTP_PERIOD - timeinfo->tm_sec % TOTP_PERIOD; 
     return val;
 }
 
@@ -25,9 +26,11 @@ void on_totp_component_label_value_changed(lv_event_t *e) {
     lv_obj_t *label = lv_event_get_target(e);
     TotpValueChangeEvent * data = (TotpValueChangeEvent *)lv_event_get_param(e);
     char *totp = get_totp_by_index(data->index);
-    if(totp){
-        // NOTE: we copy the value to the label instead of using its reference because the mem address where the totp pointer points to could be dealocated
-        lv_label_set_text(label, strdup(totp));
+    // NOTE: a copy of the value stored at *totp (ref) is created so that it can be dealocated or changed without compromising what is currently being displayed
+    char *temp = strdup(totp);
+    if(temp){
+        lv_label_set_text(label, temp);
+        free(temp);
     }
 }
 


### PR DESCRIPTION
- move constants to its own header called constants.h
- get_steps is called once and then shared between all TOTPs because we are assuming all fo them use the same TOTP_PERIOD of 30 seconds
- simplify the logic that decides when to generate new TOTPs and refresh them