### PR TITLE
Fixes 'P"?'

### DIFF
--- a/src/totp-map.c
+++ b/src/totp-map.c
@@ -80,9 +80,3 @@ void print(){
         printf("%s: %d, %s, %s\n", keys[i], decodedBase32Secrets[i].length, decodedBase32Secrets[i].value, totps[i]);
     }
 }
-
-void print_totps(){
-    for(int i = 0; i < size; i++) {
-        printf("%s: %d\n", keys[i], totps[i]);
-    }
-}

--- a/src/totp-map.h
+++ b/src/totp-map.h
@@ -42,9 +42,6 @@ char *get_totp(char key[]);
 // Function to get the totp using the array index
 char* get_totp_by_index(int index);
 
-// Function to print all totps with their respective service name
-void print_totps(); 
-
 // Function to print the map
 void print(); 
 

--- a/src/ui/screens/ui_totp_screen.c
+++ b/src/ui/screens/ui_totp_screen.c
@@ -9,6 +9,7 @@
 
 extern char keys[MAX_NUMBER_OF_SERVICES][MAX_SERVICE_NAME_LENGTH];
 extern char totps[MAX_NUMBER_OF_SERVICES][MAX_TOTP_LENGTH];
+extern int size;
 
 #define LV_LABEL_SCROLL_SPEED (15)
 
@@ -76,10 +77,8 @@ void ui_totp_screen_screen_init(void){
     lv_obj_set_layout(ui_totp_screen, LV_LAYOUT_FLEX);
 
     // NOTE: create 1 component for each TOTP
-	for(int i = 0; i < MAX_NUMBER_OF_SERVICES; i++){
-        if (totps[i][0] != '\0') {
-            create_totp_component(ui_totp_screen, keys[i], totps[i], 30, 30);
-        }
+	for(int i = 0; i < size; i++){
+        create_totp_component(ui_totp_screen, keys[i], totps[i], 30, 30);
     }
 }
 

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -22,10 +22,12 @@ int calculate_new_bar_value(){
 }
 
 void on_totp_component_label_value_changed(lv_event_t *e) {
-    LV_LOG_INFO("on_totp_component_label_value_changed");
+    LV_LOG_TRACE("on_totp_component_label_value_changed");
     lv_obj_t *label = lv_event_get_target(e);
     TotpValueChangeEvent * data = (TotpValueChangeEvent *)lv_event_get_param(e);
     char *totp = get_totp_by_index(data->index);
+
+    LV_LOG_TRACE("totp: %s index: %d", totp, data->index);
     // NOTE: a copy of the value stored at *totp (ref) is created so that it can be dealocated or changed without compromising what is currently being displayed
     char *temp = strdup(totp);
     if(temp){
@@ -35,7 +37,7 @@ void on_totp_component_label_value_changed(lv_event_t *e) {
 }
 
 void on_totp_component_bar_value_changed(lv_event_t *e){
-    LV_LOG_INFO("on_totp_component_bar_value_changed");
+    LV_LOG_TRACE("on_totp_component_bar_value_changed");
     lv_obj_t *bar = lv_event_get_target(e);
     int val = calculate_new_bar_value();
     lv_bar_set_value(bar, val, LV_ANIM_OFF);


### PR DESCRIPTION
Now the `totps[i]` mem is properly managed so that it is always filled with new totps. After generating the new totp, the code writes it to totps[i] mem and includes the null-termination character. Then after its data is written to totps[i], newTotp's mem is dealocated to avoid memory leaks.