### PR TITLE
Fix MQTT connection

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,6 +34,10 @@ build_flags =
     -Wall
     -D WIFI_SSID=\"${sysenv.WIFI_SSID}\"
     -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD}\"
+    -D MQTT_PORT=\"${sysenv.MQTT_PORT}\"
+    -D MQTT_SERVER=\"${sysenv.MQTT_SERVER}\"
+    -D MQTT_USERNAME=\"${sysenv.MQTT_USERNAME}\"
+    -D MQTT_PASSWORD=\"${sysenv.MQTT_PASSWORD}\"
     -D PIN_HASH=\"${sysenv.PIN_HASH}\"
     -D PIN_KEY=\"${sysenv.PIN_KEY}\"
     -D USER_SETUP_LOADED=1

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,7 +18,7 @@
 #define KEYS_FILE_PATH "/keys.txt"
 
 // MQTT
-#define MQTT_RECONNECT_INTERVAL 5000
+#define MQTT_RECONNECT_INTERVAL 60000
 #define MQTT_MAX_PAYLOAD_SIZE 1024
 #define MQTT_WRITE_NEW_SECRET_TOPIC "esp32-totp-write-new-secret"
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -17,16 +17,9 @@
 
 #define KEYS_FILE_PATH "/keys.txt"
 
-// MQTT Broker
-#define MQTT_SERVER "192.168.31.198"
-#define MQTT_PORT 1883
-#define MQTT_USERNAME "MQTT_USERNAME"
-#define MQTT_PASSWORD "MQTT_PASSWORD"
+// MQTT
 #define MQTT_RECONNECT_INTERVAL 5000
 #define MQTT_MAX_PAYLOAD_SIZE 1024
-
-// MQTT Topics
-// NOTE: this topic is used to create new secrets in the sd card
 #define MQTT_WRITE_NEW_SECRET_TOPIC "esp32-totp-write-new-secret"
 
 // PIN

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -1,71 +1,114 @@
 #include <WiFi.h>
 #include <PubSubClient.h>
+#include <stdbool.h>
 #include "constants.h"
 
-struct PayloadData {
+#ifndef MQTT_USERNAME
+  #warning "MQTT_USERNAME is not defined! Please define MQTT_USERNAME."
+#else
+  #pragma message "MQTT_USERNAME is set to: " MQTT_USERNAME
+#endif
+
+#ifndef MQTT_PASSWORD
+  #warning "MQTT_PASSWORD is not defined! Please define MQTT_PASSWORD."
+#else
+  #pragma message "MQTT_PASSWORD is set to: " MQTT_PASSWORD
+#endif
+
+#ifndef MQTT_SERVER
+  #warning "MQTT_SERVER is not defined! Please define MQTT_SERVER."
+#elif defined(MQTT_PORT)
+  #pragma message "MQTT_SERVER is set to: " MQTT_SERVER
+  #pragma message "MQTT_PORT is set to: " MQTT_PORT
+  WiFiClient espClient;
+  PubSubClient client(espClient);
+  #else
+  #warning "MQTT_SERVER is defined but MQTT_PORT is not defined! Please define MQTT_PORT."
+#endif
+
+struct PayloadData{
   byte payload[MQTT_MAX_PAYLOAD_SIZE];
   unsigned int length;
 };
 
-WiFiClient espClient;
-PubSubClient client(espClient);
+bool isMqttConfigured = false;
 
-char mqttServer[] = MQTT_SERVER;
 volatile bool processMqttMessage = false;
 volatile PayloadData globalPayload = {{0}, 0};
+unsigned long lastReconnectAttempt = 0;
 
-void print_mqtt_topic_message(char* topic, byte* payload, unsigned int length) {
-    // NOTE: Print topic
-    Serial.print("MQTT Message arrived on topic: ");
-    Serial.println(topic);
-    
-    // NOTE: Print payload
-    Serial.println("With Payload:");
-    char message[length+1];
-    memcpy(message, payload, length);
-    message[length] = '\0';
 
-    Serial.println(message);
+void print_mqtt_topic_message(char *topic, byte *payload, unsigned int length){
+  // NOTE: Print topic
+  Serial.print("MQTT Message arrived on topic: ");
+  Serial.println(topic);
+
+  // NOTE: Print payload
+  Serial.println("With Payload:");
+  char message[length + 1];
+  memcpy(message, payload, length);
+  message[length] = '\0';
+
+  Serial.println(message);
 }
 
 // NOTE: store received message in memory to process it later
-void on_mqtt_message_received(char* topic, byte* payload, unsigned int length) {
+void on_mqtt_message_received(char *topic, byte *payload, unsigned int length){
   print_mqtt_topic_message(topic, payload, length);
-  if(length <= MQTT_MAX_PAYLOAD_SIZE) {
+  if(length <= MQTT_MAX_PAYLOAD_SIZE){
     processMqttMessage = true;
     byte nonVolatilePayload[MQTT_MAX_PAYLOAD_SIZE];
     memcpy(nonVolatilePayload, payload, length);
-    for(unsigned int i = 0; i < length; i++) {
-        globalPayload.payload[i] = nonVolatilePayload[i];
+    for (unsigned int i = 0; i < length; i++){
+      globalPayload.payload[i] = nonVolatilePayload[i];
     }
     globalPayload.length = length;
   }
 }
 
-void init_mqtt(){
-  client.setServer(mqttServer, MQTT_PORT);
-  client.setCallback(on_mqtt_message_received);
+
+bool connect(const char *topic){
+  if(strlen(MQTT_USERNAME) && strlen(MQTT_PASSWORD)){
+    client.connect(topic, MQTT_USERNAME, MQTT_PASSWORD);
+  } else {
+    client.connect(topic);
+  }
+
+  return client.connected();
+}
+
+void connect_to_topic(const char * topic){
+  if(connect(topic)){
+    Serial.println("Connected");
+    client.subscribe(topic);
+    Serial.printf("Subscribed to %s\n", topic);
+    lastReconnectAttempt = 0;
+  } else {
+    Serial.printf("Failed, rc=%d. Will try again in %d ms\n", client.state(), MQTT_RECONNECT_INTERVAL);
+  }
 }
 
 void connect_to_mqtt(){
-	unsigned long currentMillis = millis();
-	// NOTE: connect to MQTT topics every 5000 ms
-	static unsigned long lastMqttReconnectAttempt = 0;
-	if (!client.connected() && (currentMillis - lastMqttReconnectAttempt > MQTT_RECONNECT_INTERVAL)) {
-		lastMqttReconnectAttempt = currentMillis;
-		Serial.print("Connecting to MQTT...");
-		if (client.connect("esp32-mfa-totp-generator")) {
-			Serial.println("connected");
-			client.subscribe(MQTT_WRITE_NEW_SECRET_TOPIC);
-			Serial.println("subscribed to esp32-totp-write-new-secret topic");
-		} else {
-			Serial.print("failed, rc=");
-			Serial.print(client.state());
-			Serial.printf("will try again in %d ms\n", MQTT_RECONNECT_INTERVAL);
-		}
-	} else {
-		client.loop();
-	}
+  if(isMqttConfigured){
+    if(!client.connected()){
+      unsigned long currentMillis = millis();
+      // NOTE: try to connect to MQTT topics every 5000 ms
+      if (currentMillis - lastReconnectAttempt > MQTT_RECONNECT_INTERVAL) {
+        lastReconnectAttempt = currentMillis;
+        connect_to_topic(MQTT_WRITE_NEW_SECRET_TOPIC);
+      }
+    } else {
+      client.loop();
+    }
+  }
 }
 
-
+void init_mqtt(){
+  if(strlen(MQTT_SERVER) && strlen(MQTT_PORT)){
+    Serial.println("Configuring MQTT client");
+    unsigned long mqtt_port = strtoul(MQTT_PORT, NULL, 10);
+    client.setServer(MQTT_SERVER, mqtt_port);
+    client.setCallback(on_mqtt_message_received);
+    isMqttConfigured = true;
+  }
+}

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -1,27 +1,17 @@
 #include <WiFi.h>
 
-#ifndef WIFI_SSID
-  #error "WIFI_SSID is not defined! Please define WIFI_SSID."
-#else
-  #pragma message "WIFI_SSID is set to: " WIFI_SSID
-#endif
-
-#ifndef WIFI_PASSWORD
-  #error "WIFI_PASSWORD is not defined! Please define WIFI_PASSWORD."
-#else
-  #pragma message "WIFI_PASSWORD is set to: " WIFI_PASSWORD
-#endif
-
-
-void init_wifi(){
-  if(WIFI_SSID == NULL || WIFI_PASSWORD == NULL){
+void init_wifi()
+{
+  if (WIFI_SSID == NULL || WIFI_PASSWORD == NULL)
+  {
     Serial.printf("Failed to get WiFi details from environment variables");
     return; // Or handle error appropriately
   }
 
   Serial.printf("Connecting to %s", WIFI_SSID);
   WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-  while (WiFi.status() != WL_CONNECTED) {
+  while (WiFi.status() != WL_CONNECTED)
+  {
     delay(500);
     Serial.print(".");
   }

--- a/src/wifi.hpp
+++ b/src/wifi.hpp
@@ -4,13 +4,17 @@
 #include <WiFi.h>
 
 #ifndef WIFI_SSID
-#define WIFI_SSID (char*)"CHOCOLATE"
+#error "WIFI_SSID is not defined! Please define WIFI_SSID."
+#else
+#pragma message "WIFI_SSID is set to: " WIFI_SSID
 #endif
 
 #ifndef WIFI_PASSWORD
-#define WIFI_PASSWORD (char*)"CHOCOLATE"
+#error "WIFI_PASSWORD is not defined! Please define WIFI_PASSWORD."
+#else
+#pragma message "WIFI_PASSWORD is set to: " WIFI_PASSWORD
 #endif
 
 void init_wifi();
 
-#endif //WIFICONNECTION_H 
+#endif // WIFICONNECTION_H


### PR DESCRIPTION
- Due to the MQTT_RECONNECTION_INTERVAL being smaller than the connection timeout, TOTP codes weren't being updated because the code was constantly retrying to reconnect to the MQTT server. Now, reconnections occur once every minute. However, the board still freezes for a few seconds whenever a connection retry occurs.
- MQTT is only configured if MQTT_SERVER and MQTT_PORT are set during builds.
- MQTT_SERVER, MQTT_PORT, MQTT_USERNAME, MQTT_PASSWORD can now be set as env variables.
- Moved WIFI_SSID and WIFI_PASSWORD `#define`s from wifi.cpp to wifi.hpp