### PR TITLE
feat: add error handling for missing SD card or config files

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -230,12 +230,12 @@ Configuration Configuration::parse(const String &json_string)
 	return config;
 }
 
-bool Configuration::is_authentication_configured()
+bool Configuration::is_authentication_configured() const
 {
 	return !authentication.pin.hash.isEmpty() && !authentication.pin.key.isEmpty();
 }
 
-bool Configuration::is_manager_configured()
+bool Configuration::is_manager_configured() const
 {
 	return !manager.authentication.username.isEmpty() && !manager.authentication.password.isEmpty() && !manager.authentication.key.isEmpty();
 }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -49,8 +49,8 @@ public:
 	static Configuration load();
 	static Configuration parse(const String &json_string);
 	bool save() const;
-	bool is_authentication_configured();
-	bool is_manager_configured();
+	bool is_authentication_configured() const;
+	bool is_manager_configured() const;
 };
 
 #endif // CONFIGURATION_H

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -106,7 +106,7 @@ void on_display_change(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *c
     lv_disp_flush_ready(disp);
 }
 
-void init_display(Configuration config)
+void init_display(const Configuration& config)
 {
     ESP_LOGI(TAG, "initializing display");
 
@@ -160,27 +160,4 @@ void display_register()
     ESP_LOGD(TAG, "display registered in lvgl");
 }
 
-void init_minimal_display()
-{
-    ESP_LOGI(TAG, "initializing minimal display");
 
-    ESP_LOGD(TAG, "initiliazing backlight");
-    pinMode(TFT_BCKL, OUTPUT);
-    digitalWrite(TFT_BCKL, HIGH);
-    ESP_LOGD(TAG, "backlight initialized");
-
-    ESP_LOGD(TAG, "initializing tft");
-    tft.begin();
-    tft.setSwapBytes(true);
-    tft.fillScreen(ILI9341_PINK);
-    tft.setRotation(2);
-    ESP_LOGD(TAG, "tft initialized");
-
-    display_is_active = true;
-    ESP_LOGD(TAG, "initializing lvgl");
-    lv_init();
-    ESP_LOGD(TAG, "initializing lvgl");
-    display_register();
-
-    ESP_LOGI(TAG, "minimal display initialized");
-}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -159,3 +159,28 @@ void display_register()
     reset_display_off_timer();
     ESP_LOGD(TAG, "display registered in lvgl");
 }
+
+void init_minimal_display()
+{
+    ESP_LOGI(TAG, "initializing minimal display");
+
+    ESP_LOGD(TAG, "initiliazing backlight");
+    pinMode(TFT_BCKL, OUTPUT);
+    digitalWrite(TFT_BCKL, HIGH);
+    ESP_LOGD(TAG, "backlight initialized");
+
+    ESP_LOGD(TAG, "initializing tft");
+    tft.begin();
+    tft.setSwapBytes(true);
+    tft.fillScreen(ILI9341_PINK);
+    tft.setRotation(2);
+    ESP_LOGD(TAG, "tft initialized");
+
+    display_is_active = true;
+    ESP_LOGD(TAG, "initializing lvgl");
+    lv_init();
+    ESP_LOGD(TAG, "initializing lvgl");
+    display_register();
+
+    ESP_LOGI(TAG, "minimal display initialized");
+}

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -11,7 +11,7 @@
 #include "./ui/ui.h"
 #include "config.hpp"
 
-void init_display(Configuration config);
+void init_display(const Configuration& config);
 void display_register();
 void turn_off_display();
 void turn_on_display();
@@ -19,6 +19,5 @@ void reset_display_off_timer();
 void check_display_timeout();
 void display_handle_single_touch();
 void display_handle_double_touch();
-void init_minimal_display();
 
 #endif // DISPLAY_H

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -19,5 +19,6 @@ void reset_display_off_timer();
 void check_display_timeout();
 void display_handle_single_touch();
 void display_handle_double_touch();
+void init_minimal_display();
 
 #endif // DISPLAY_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,6 @@ void setup()
   Serial.begin(115200);
 #endif
   ESP_LOGI(TAG, "----------- begin setup ------------");
-  init_minimal_display();
   try
   {
     init_storage();
@@ -61,6 +60,8 @@ void setup()
   }
   catch (const std::runtime_error &e)
   {
+    Configuration config;
+    init_display(config);
     ESP_LOGE(TAG, "A fatal error occurred: %s", e.what());
     ui_show_error_screen("Fatal Error", "Could not read\nconfig.yml or services.yml.\nPlease check the SD card.");
     while (1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "wifi.hpp"
 #include "touch-screen.hpp"
 #include "manager.hpp"
+#include "display.hpp"
 
 static const char *TAG = "main";
 
@@ -32,28 +33,42 @@ void setup()
   Serial.begin(115200);
 #endif
   ESP_LOGI(TAG, "----------- begin setup ------------");
-  init_storage();
-  load_services();
-  Configuration config = Configuration::load();
-
-  init_auth(
-      config.authentication.pin.hash.c_str(),
-      config.authentication.pin.key.c_str(),
-      config.manager.authentication.username.c_str(),
-      config.manager.authentication.password.c_str(),
-      config.manager.authentication.key.c_str(),
-      config.manager.authentication.session_length);
-  init_touch_screen(config);
-  const char *local_network_ip = init_wifi(config).c_str();
-  init_clock();
-
-  if (config.is_manager_configured())
+  init_minimal_display();
+  try
   {
-    init_manager(config, local_network_ip);
+    init_storage();
+    load_services();
+    Configuration config = Configuration::load();
+
+    init_auth(
+        config.authentication.pin.hash.c_str(),
+        config.authentication.pin.key.c_str(),
+        config.manager.authentication.username.c_str(),
+        config.manager.authentication.password.c_str(),
+        config.manager.authentication.key.c_str(),
+        config.manager.authentication.session_length);
+    init_touch_screen(config);
+    const char *local_network_ip = init_wifi(config).c_str();
+    init_clock();
+
+    if (config.is_manager_configured())
+    {
+      init_manager(config, local_network_ip);
+    }
+    init_ui(
+        config.is_authentication_configured(),
+        config.authentication.unlock_attempts);
   }
-  init_ui(
-      config.is_authentication_configured(),
-      config.authentication.unlock_attempts);
+  catch (const std::runtime_error &e)
+  {
+    ESP_LOGE(TAG, "A fatal error occurred: %s", e.what());
+    ui_show_error_screen("Fatal Error", "Could not read\nconfig.yml or services.yml.\nPlease check the SD card.");
+    while (1)
+    {
+      ui_task_handler();
+      vTaskDelay(100 / portTICK_PERIOD_MS);
+    }
+  }
   ESP_LOGI(TAG, "----------- end setup ------------");
 }
 

--- a/src/touch-screen.cpp
+++ b/src/touch-screen.cpp
@@ -16,7 +16,7 @@ void double_touch_handler()
 	ESP_LOGV(TAG, "double touch handler executed");
 }
 
-void init_touch_screen(Configuration config)
+void init_touch_screen(const Configuration& config)
 {
 	ESP_LOGI(TAG, "initializing touch screen");
 

--- a/src/touch-screen.hpp
+++ b/src/touch-screen.hpp
@@ -6,7 +6,7 @@
 #include "display.hpp"
 #include "touch.hpp"
 
-void init_touch_screen(Configuration config);
+void init_touch_screen(const Configuration& config);
 void display_timeout_handler();
 
 #endif // TOUCH_SCREEN

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -98,3 +98,21 @@ void ui_task_handler()
 {
     lv_task_handler();
 }
+
+void ui_show_error_screen(const char *title, const char *message)
+{
+    lv_obj_t *error_screen = lv_obj_create(NULL);
+    lv_obj_clear_flag(error_screen, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t *title_label = lv_label_create(error_screen);
+    lv_label_set_text(title_label, title);
+    lv_obj_set_style_text_font(title_label, &lv_font_montserrat_22, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 20);
+
+    lv_obj_t *message_label = lv_label_create(error_screen);
+    lv_label_set_text(message_label, message);
+    lv_obj_set_style_text_align(message_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(message_label, LV_ALIGN_CENTER, 0, 0);
+
+    lv_scr_load(error_screen);
+}

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -42,6 +42,7 @@ extern "C"
 	void ui_touch_calibration_screen_step_2();
 	void ui_touch_calibration_screen_step_3();
 	void ui_touch_calibration_screen_destroy();
+	void ui_show_error_screen(const char *title, const char *message);
 
 #ifdef __cplusplus
 } /*extern "C"*/


### PR DESCRIPTION
## Summary

This PR addresses a critical issue in the onboarding process where the device would enter a bootloop if the SD card or the required `config.yml` and `services.yml` files were missing. This left users without any feedback, making it difficult to diagnose the initial setup problem.

With this change, the device now gracefully handles these errors by displaying a clear, user-friendly message on the screen, guiding the user on how to fix the problem.

## Changes

- **Graceful Error Handling:** Implemented a `try...catch` block in the main `setup()` function to prevent crashes and bootloops caused by initialization errors.
- **Early Display Initialization:** A minimal display initialization is now performed at the very beginning of the boot sequence. This ensures that the screen is ready to display feedback even if the full configuration fails.
- **User-Friendly Error Screen:** A new UI screen (`ui_show_error_screen`) has been added to inform the user about the exact nature of the problem (e.g., missing SD card or configuration files) and how to resolve it.
- **Halt on Failure:** Instead of rebooting, the device now halts on a fatal initialization error, keeping the error message visible.

## How to Test

1.  Build and flash the firmware from the `feat/improve-onboarding` branch.
2.  Boot the ESP32 device **without an SD card inserted**.
3.  **Expected Result:** The device should display a "Fatal Error" screen with the message "Could not read config.yml or services.yml. Please check the SD card." instead of bootlooping.
4.  Insert an SD card with valid `config.yml` and `services.yml` files and reboot the device.
5.  **Expected Result:** The device should boot up normally.

## Related Issues

@AllanOricil  wrote in #46 : "My initial design was horrible for onboarding new users". These are the kinds of things you always prefer to do later. Maybe it will help this great project a little.

## Screenshot

![IMG_20251207_131351_835](https://github.com/user-attachments/assets/cc13b864-8ab0-47c2-a9ae-09fbb0f8eb25)

